### PR TITLE
[FIX] #57 면접 생성 페이지 - 면접 진행 시간과 타임테이블 연동

### DIFF
--- a/src/components/timeTable/TimeTable.tsx
+++ b/src/components/timeTable/TimeTable.tsx
@@ -7,6 +7,7 @@ import { useRecoilState } from 'recoil';
 import { scheduleAtom } from '../../recoil/interviewMake2Atom';
 
 type TimeTable = {
+	interviewTime: number;
 	selectedDates: string[];
 	availableTimes?: Date[];
 	isConfirmed?: boolean;
@@ -14,10 +15,9 @@ type TimeTable = {
 	setClickedTime?: (time: Date) => void;
 };
 
-const TimeTable = ({ selectedDates, availableTimes, isConfirmed, clickedTime, setClickedTime }: TimeTable) => {
+const TimeTable = ({ interviewTime, selectedDates, availableTimes, isConfirmed, clickedTime, setClickedTime }: TimeTable) => {
 	const [schedule, setSchedule] = useRecoilState(scheduleAtom);
-	// const [clickedTime, setClickedTime] = useState<Date>();
-	const [hourlyChunks, setHourlyChunks] = useState<number>(2);
+	const hourlyChunks = 60 / interviewTime;
 
 	const handleClickDateCell = (time: Date, blocked: boolean) => {
 		if (!blocked) {
@@ -26,7 +26,6 @@ const TimeTable = ({ selectedDates, availableTimes, isConfirmed, clickedTime, se
 	};
 
 	const renderingDates = selectedDates.map((date) => new Date(date));
-	// const blockedTimes = [new Date('2024-02-06T10:00:00'), new Date('2024-02-06T13:00:00')];
 
 	const renderCustomDateCell = (date: Date, selected: boolean, blocked: boolean, clicked: boolean) => {
 		if (setClickedTime) {

--- a/src/pages/interviewApply/inputSchedule/InterviewApplyInputSchedule.tsx
+++ b/src/pages/interviewApply/inputSchedule/InterviewApplyInputSchedule.tsx
@@ -61,7 +61,7 @@ function InterviewApplyInputSchedule() {
 						{/* sortedDates를 5개씩 끊어서 SplideSlide에 전달 */}
 						{chunkArray(sortedDates, 5).map((chunk, index) => (
 							<SplideSlide key={index}>
-								<TimeTable selectedDates={chunk} availableTimes={availableTimes} />
+								<TimeTable interviewTime={30} selectedDates={chunk} availableTimes={availableTimes} />
 							</SplideSlide>
 						))}
 					</Splide>

--- a/src/pages/interviewMake/InterviewMake2.tsx
+++ b/src/pages/interviewMake/InterviewMake2.tsx
@@ -9,11 +9,13 @@ import { useNavigate } from 'react-router-dom';
 import { Splide, SplideSlide } from '@splidejs/react-splide';
 import '@splidejs/react-splide/css/core';
 import { chunkArray } from '../../utils/chunkArray';
+import { interviewTimeAtom } from '../../recoil/interviewAtoms';
 
 function InterviewMake2() {
 	const selectedDates = useRecoilValue(selectedDatesAtom);
 	const schedule = useRecoilValue(scheduleAtom);
 	const [sortedDates, setSortedDates] = useState<string[]>([]);
+	const interviewTime = useRecoilValue(interviewTimeAtom);
 
 	const splideRef = useRef<Splide>(null);
 
@@ -91,7 +93,7 @@ function InterviewMake2() {
 						{/* sortedDates를 5개씩 끊어서 SplideSlide에 전달 */}
 						{chunkArray(sortedDates, 5).map((chunk, index) => (
 							<SplideSlide key={index}>
-								<TimeTable selectedDates={chunk} />
+								<TimeTable interviewTime={interviewTime} selectedDates={chunk} />
 							</SplideSlide>
 						))}
 					</Splide>

--- a/src/pages/interviewTimetable/progress/TimeTableProgress.tsx
+++ b/src/pages/interviewTimetable/progress/TimeTableProgress.tsx
@@ -75,7 +75,7 @@ function TimeTableProgress() {
 							{/* sortedDates를 5개씩 끊어서 SplideSlide에 전달 */}
 							{chunkArray(sortedDates, 5).map((chunk, index) => (
 								<SplideSlide key={index}>
-									<TimeTable selectedDates={chunk} availableTimes={availableTimes} isConfirmed={true} clickedTime={clickedTime} setClickedTime={setClickedTime} />
+									<TimeTable interviewTime={30} selectedDates={chunk} availableTimes={availableTimes} isConfirmed={true} clickedTime={clickedTime} setClickedTime={setClickedTime} />
 								</SplideSlide>
 							))}
 						</Splide>


### PR DESCRIPTION
## 🚀 개요
<!---- resolved: #(Isuue Number) e.g resolved: #1 -->
resolved: #57 
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!-- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
면접 생성 페이지의 면접 진행 시간에 따라 타임테이블 셀이 나눠지도록 연동하였습니다.

## ⚙️ 작업 내역
<!-- 어떤 변경 사항이 있나요? 구체적인 작업 내역을 리스트로 작성해주세요 -->
- 면접 생성 페이지 면접 진행 시간과 타임테이블 연동

## ✏️ 참고 사항
<!-- 팀원들에게 전달해야할 참고 사항을 작성해주세요 -->
면접 생성 페이지 외 타임테이블은 아직 api 연결이 안되었기 때문에 30분 간격이 고정되어있습니다.

## ✅ PR 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).